### PR TITLE
Fix Broken Dockerfile and Optimize for Lightweight Build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,14 @@
 # docker build . -t erever
 # docker run -it erever
-FROM ubuntu:22.04
+FROM python:3.11-alpine
 
-ENV DEBIAN_FRONTEND noninteractive
-
-RUN apt update -y
-RUN apt install -y \
-    python3 \
-    python-is-python3 \
-    python3-pip \
-    vim
+RUN apk update && apk add \
+    vim \
+    py3-pip \
+    git \
+    bash
 
 COPY . /erever
 WORKDIR /erever
 RUN pip install .
+


### PR DESCRIPTION
The existing Dockerfile is currently broken and uses an Ubuntu base image, making it heavier than needed. This pull request:

1. Fixes the build errors.
2. Switches to a lightweight `python:3.11-alpine` base image to reduce image size.

Tested successfully with `docker build` and `docker run`.
